### PR TITLE
Use "Active" cases as current

### DIFF
--- a/coronavirus/__init__.py
+++ b/coronavirus/__init__.py
@@ -19,9 +19,12 @@ class JohnsHopkinsCase:
     latitude: float
     longitude: float
     updated: int
+    active: int
 
     @property
     def current(self):
+        if self.active:
+            return self.active
         if None in (self.confirmed, self.deaths, self.recovered):
             return None
         return self.confirmed - self.deaths - self.recovered
@@ -38,6 +41,7 @@ class JohnsHopkinsCase:
             latitude=attrs["Lat"],
             longitude=attrs["Long_"],
             updated=attrs["Last_Update"],
+            active=attrs["Active"],
         )
 
 


### PR DESCRIPTION
Some countries (for instance Sweden and Belgium) does not report "recovered" cases, leading to "current" being "None".
Since we already have the field "Active" in the json file, it seems like a better choice to use that. 
But we are still falling back to the old method if we dont have a number for "Active" cases (although at least today it seems like that is present for all countries).